### PR TITLE
compilation support for core v0.10.0 release

### DIFF
--- a/lib/async/cli.ml
+++ b/lib/async/cli.ml
@@ -31,7 +31,7 @@ end
 (******************************************************************************)
 let tree : Command.t =
   let open Command.Let_syntax in
-  Command.async_or_error'
+  Command.async_or_error
     ~summary:"print a directory tree"
     [%map_open
       let log_level = Param.log_level

--- a/phat-async.opam
+++ b/phat-async.opam
@@ -12,11 +12,11 @@ build: [
 ]
 
 depends: [
-  "async" {>= "v0.9.0"}
+  "async" {>= "v0.10.0"}
   "jbuilder" {build}
   "ounit" # {test} TODO: Make ounit a dependency only if running tests.
   "phat-base"
   "ppx_jane"
 ]
 
-ocaml-version: [ >= "4.01.0" ]
+ocaml-version: [ >= "4.06.0" ]

--- a/phat-base.opam
+++ b/phat-base.opam
@@ -12,9 +12,9 @@ build: [
 ]
 
 depends: [
-  "core_kernel" {>= "v0.9.0"}
+  "core_kernel" {>= "v0.10.0"}
   "jbuilder" {build}
   "ppx_jane"
 ]
 
-ocaml-version: [ >= "4.01.0" ]
+ocaml-version: [ >= "4.06.0" ]


### PR DESCRIPTION
This PR fixes compilation errors to support the latest released jane street core `v0.10.0`.